### PR TITLE
Disable neo-tree in LazyVim setup

### DIFF
--- a/tools/nvim/lua/plugins/neo-tree.lua
+++ b/tools/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,4 @@
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  enabled = false,
+}


### PR DESCRIPTION
## Summary
- disable nvim-neo-tree plugin through a Lazy spec so LazyVim stops loading it

## Testing
- nvim --headless "+Lazy sync" "+qa" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e13290dc048325a6fbfee0ee258bd2